### PR TITLE
ci: 移除对 pull_request 事件的触发

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,8 @@ name: Deploy to Github Pages
 on:
     push:
         branches: [main]
-    pull_request:
-        branches: [main]
+    # pull_request:
+    #     branches: [main]
 
 jobs:
     build:


### PR DESCRIPTION
移除 `.github/workflows/deploy.yml` 中对 `pull_request` 事件的触发，以避免在每次 PR 时重复部署