### PR TITLE
refactor(hugo.toml): 更新配置以优化主题和画廊设置

### DIFF
--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -1,6 +1,6 @@
 copyright = "2017-2025 © Debug客栈, by @debuginn."
 defaultContentLanguage = "zh-cn"
-disableKinds = ["taxonomy", "term"]
+disableKinds = ["taxonomy"]
 enableRobotsTXT = true
 languageCode = "zh-cn"
 timeZone = "Asia/Shanghai"
@@ -9,7 +9,8 @@ title = "Debug客栈"
 
 [params]
 title = "摄影展"
-defaultTheme = "light"
+defaultTheme = "dark"
+description = "您好，我是 Meng小羽，非标准程序猿，爱好 Coding、Music and Photography。"
 [params.author]
 email = "debuginn@icloud.com"
 name = "Meng小羽"
@@ -17,6 +18,10 @@ name = "Meng小羽"
 website = "https://debuginn.com"
 email = "mailto:debuginn@icloud.com"
 github = "https://github.com/debuginn"
+[params.gallery]
+boxSpacing = 10
+targetRowHeight = 288
+targetRowHeightTolerance = 0.25
 
 [outputs]
 home = ["HTML", "RSS"]
@@ -33,7 +38,9 @@ includeFields = "ImageDescription|Orientation"
 
 [module]
 [module.hugoVersion]
-min = "0.147.2"
+min = "0.121.2"
+[[module.imports]]
+path = "github.com/nicokaiser/hugo-theme-gallery/v4"
 
 [services]
 [services.rss]


### PR DESCRIPTION
- 将默认主题更改为“dark”以改善用户体验
- 添加画廊相关配置，包括boxSpacing、targetRowHeight和targetRowHeightTolerance
- 更新Hugo版本至0.121.2并引入hugo-theme-gallery模块
- 移除“term”类型的禁用，保留“taxonomy”禁用