### PR TITLE
ci(workflow): 在部署流程中添加Hugo模块初始化步骤

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
                   go-version: "^1.17.0"
             - run: go version
 
+            - name: Hugo mod init
+              run: hugo mod get
+
             - name: Setup Hugo
               uses: peaceiris/actions-hugo@v2
               with:


### PR DESCRIPTION
添加hugo mod get步骤以确保在构建前正确初始化Hugo模块依赖