### PR TITLE
ci: 调整部署工作流中Hugo模块初始化的顺序

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,14 +36,14 @@ jobs:
                   go-version: "^1.17.0"
             - run: go version
 
-            - name: Hugo mod init
-              run: hugo mod get
-
             - name: Setup Hugo
               uses: peaceiris/actions-hugo@v2
               with:
                   hugo-version: "latest"
                   extended: true
+            
+            - name: Hugo mod init
+              run: hugo mod get
 
             - name: Build
               run: hugo --minify --gc


### PR DESCRIPTION
将Hugo模块初始化步骤移到Hugo安装之后，确保环境准备就绪后再获取模块依赖
```

这个提交消息：
1. 使用了`ci`类型，因为是修改CI/CD工作流文件
2. 省略了scope，因为改动范围明确在部署工作流
3. 描述部分简明扼要说明了调整顺序的操作
4. 在正文中补充说明了调整顺序的原因（确保环境准备就绪）
5. 遵循了中文的简洁表达习惯，同时保持了技术准确性