### PR TITLE
feat: 更新2022、2023和2024年度精选照片配置

### DIFF
--- a/content/2022/index.md
+++ b/content/2022/index.md
@@ -1,10 +1,13 @@
 ---
-menus: "main"
-sort_by: Name
-sort_order: desc
-title: 2022 年度精选照片
 description: 蟒山、鼓楼、凤凰岭、小米科技园、天安门、雁栖湖、龙泽站、京西小华山...
-type: gallery
+menus: "main"
+title: 2022 年度精选照片
 weight: 3
 categories: ["2022"]
+params:
+  theme: light
+resources:
+  - src: 202303120016035.jpeg
+    params:
+      cover: true
 ---

--- a/content/2023/index.md
+++ b/content/2023/index.md
@@ -1,8 +1,13 @@
 ---
-title: 2023 年度精选照片
 description: 西伯利亚的海鸥、苍山洱海、大饼的小屋、小狗老板、十七伏地魔、玉龙雪山、松赞林寺、夜爬灵山...
 menus: "main"
+title: 2023 年度精选照片
 weight: 2
-featured_image: 202312241509754.jpg
 categories: ["2023"]
+params:
+  theme: light
+resources:
+  - src: DSC01373.JPG
+    params:
+      cover: true
 ---

--- a/content/2024/index.md
+++ b/content/2024/index.md
@@ -1,9 +1,13 @@
 ---
-title: 2024 年度精选照片
 description: 今年，我也走过了许多地方，见证了人世间的悲欢离合，用镜头记录下无数动人的瞬间。赛里木湖的湛蓝、《苹果香》中的蓝色小屋、风吹草低的牛羊、第四纪火山的奇特地貌、一望无际的戈壁滩、肉眼可见的深邃银河、万人大合唱的震撼、还有海上的日落与月升……每一处风景都饱含故事，每一帧画面都充满了意义。这一年，旅途不仅拓宽了视野，更丰富了心灵。
 menus: "main"
+title: 2024 年度精选照片
 weight: 1
-# featured_image: DSC05153.JPG
-# featured: true
 categories: ["2024"]
+params:
+  theme: light
+resources:
+  - src: DSC05153.JPG
+    params:
+      cover: true
 ---


### PR DESCRIPTION
为2022、2023和2024年度精选照片添加了资源参数，设置主题为“light”，并指定了封面图片，以增强画廊展示效果。